### PR TITLE
Fix/travis sass failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: node_js
 node_js:
   - "stable"
+
 cache:
   directories:
   - node_modules
+
 script:
   - npm test
   - npm run build

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom",
-    "fix": "eslint --fix src,
+    "fix": "eslint --fix src",
     "postinstall": "npm rebuild node-sass"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js --env=jsdom",
-    "fix": "eslint --fix src"
+    "fix": "eslint --fix src,
+    "postinstall": "npm rebuild node-sass"
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
Looks like this change fixes the Travis CI build.  From research, it seems that Travis and node-sass, which is compiled, seems to not be pulled properly from cache, which causes the error.

Here's a link to the successful build with this branch:

https://travis-ci.org/Tandemly/eos-wallet-app/builds/268136076

There are still JS errors and eslint errors, which we should handle on another branch.