### PR TITLE
Fix transaction date error

### DIFF
--- a/src/containers/Transactions.js
+++ b/src/containers/Transactions.js
@@ -35,6 +35,10 @@ class Transactions extends Component {
 
  dataTransform(data) {
    return data.map((item) => {
+      if (item.date.month) {
+        return item;
+      }
+
      const date = new Date(item.date);
      item.date = {
        month: date.toLocaleString('en-US', { month: 'long' }).substr(0, 3),


### PR DESCRIPTION
Fixing the transaction date errors that occur when user visits a page with transactions on it twice, visible below.

![Screen Shot 2017-08-22 at 10.48.08.png](https://trello-attachments.s3.amazonaws.com/59887d5704dd3539eb7f86be/599c52514c338a9fe71b2064/70dbd933976a025263a1ac14bc467039/Screen_Shot_2017-08-22_at_10.48.08.png) 